### PR TITLE
Feature/ratelimit

### DIFF
--- a/eosio.faucet.cpp
+++ b/eosio.faucet.cpp
@@ -14,9 +14,10 @@ void faucet::send( const string to )
 
     // track history
     add_history( to );
-    add_ratelimit( to );
     prune_history();
+    prune_rate_limit();
     add_stats();
+
 }
 
 [[eosio::action]]
@@ -37,6 +38,7 @@ void faucet::test( const string address )
     require_auth( get_self() );
     add_ratelimit(address);
     prune_history();
+    prune_rate_limit();
 }
 
 void faucet::prune_history()
@@ -47,8 +49,26 @@ void faucet::prune_history()
         const auto& row = history.begin();
         const int64_t now = current_time_point().sec_since_epoch();
         const int64_t timestamp = row->timestamp.sec_since_epoch();
-        if ( timestamp < (now - MAX_AGE) ) {
+        if ( timestamp < (now - TTL_HISTORY) ) {
             history.erase( row );
+        } else {
+            break;
+        }
+        count++;
+        if ( count >= 10 ) break;
+    }
+}
+
+void faucet::prune_rate_limit()
+{
+    faucet::ratelimit_table ratelimit( get_self(), get_self().value );
+    int count = 0;
+    while ( ratelimit.begin() != ratelimit.end() ) {
+        const auto& row = ratelimit.begin();
+        const int64_t now = current_time_point().sec_since_epoch();
+        const int64_t timestamp = row->last_send_time.sec_since_epoch();
+        if ( timestamp < (now - TTL_RATE_LIMIT) ) {
+            ratelimit.erase( row );
         } else {
             break;
         }
@@ -81,14 +101,23 @@ void faucet::add_stats()
     else stats.modify( itr, get_self(), insert );
 }
 
-void faucet::add_ratelimit( const string address )
+uint64_t faucet::add_ratelimit( const string address )
 {
     faucet::ratelimit_table _ratelimit( get_self(), get_self().value );
     auto idx = _ratelimit.get_index<"by.address"_n>();
     auto it = idx.find(to_checksum(address));
 
+    // previous counter used for decrementing quantity
+    const uint64_t previous_counter = it->counter;
+
     auto insert = [&]( auto& row ) {
         const int64_t now = current_time_point().sec_since_epoch();
+        // reset last timestamp if exceeds TTL
+        if ( TTL_RATE_LIMIT < (now - row.last_send_time.sec_since_epoch()) ) {
+            row.last_send_time = current_time_point();
+            row.counter = 0;
+        }
+
         const int64_t last = row.last_send_time.sec_since_epoch();
         const int64_t diff = now - last;
         check(diff >= TIMEOUT, "eosio.faucet must wait " + to_string(TIMEOUT) + " seconds");
@@ -102,27 +131,32 @@ void faucet::add_ratelimit( const string address )
     auto itr = _ratelimit.find( it->id );
     if ( it == idx.end() ) _ratelimit.emplace( get_self(), insert );
     else _ratelimit.modify( itr, get_self(), insert );
+    return previous_counter;
 }
 
 void faucet::send_evm( const string address )
 {
+    const uint64_t counter = add_ratelimit( address );
+    const asset quantity = QUANTITY - (DECREMENT * counter) + GAS_FEE;
     const asset balance = token::get_balance( TOKEN, get_self(), EOS.code() );
     check( address.substr(0, 2) == "0x", "eosio.faucet [address] must be a valid EVM address (missing 0x prefix)");
     check( address.length() == 42, "eosio.faucet [address] must be a valid EVM address (too short)");
-    check( balance >= QUANTITY, "eosio.faucet is empty, please contact administrator");
-    transfer( get_self(), "eosio.evm"_n, {QUANTITY, TOKEN}, address);
+    check( balance >= quantity, "eosio.faucet is empty, please contact administrator");
+    transfer( get_self(), "eosio.evm"_n, {quantity, TOKEN}, address);
 }
 
 void faucet::send_eos( const string address )
 {
+    const uint64_t counter = add_ratelimit( address );
     const name account = name{address};
     const time_point_sec now = current_time_point();
     check( is_account( account ), account.to_string() + " account does not exist" );
 
     // send assets
     const asset balance = token::get_balance( TOKEN, get_self(), EOS.code() );
-    check( balance >= QUANTITY, "eosio.faucet is empty, please contact administrator");
-    transfer( get_self(), account, {QUANTITY, TOKEN}, MEMO);
+    const asset quantity = QUANTITY - (DECREMENT * counter);
+    check( balance >= quantity, "eosio.faucet is empty, please contact administrator");
+    transfer( get_self(), account, {quantity, TOKEN}, MEMO);
 }
 
 // @debug
@@ -134,7 +168,6 @@ void faucet::clear_table( T& table, uint64_t rows_to_clear )
         itr = table.erase( itr );
     }
 }
-
 
 // @[[eosio::action]]debug
 void faucet::cleartable( const name table_name, const optional<name> scope, const optional<uint64_t> max_rows )

--- a/eosio.faucet.hpp
+++ b/eosio.faucet.hpp
@@ -185,7 +185,8 @@ private :
     void send_eos( const string address );
     uint64_t add_ratelimit( const string address );
     void add_history( const string address );
-    void prune_rate_limit();
+    void prune_rate_limits();
+    void prune_rate_limit( const string address );
     void prune_history();
     void add_stats();
 };

--- a/eosio.faucet.hpp
+++ b/eosio.faucet.hpp
@@ -18,13 +18,16 @@ public:
     // CONSTANTS
     const name TOKEN = "eosio.token"_n;
     const symbol EOS = symbol{"EOS", 4};
-    const asset QUANTITY = asset{1'0100, EOS};
+    const asset QUANTITY = asset{1'0000, EOS};
+    const asset DECREMENT = asset{0'1000, EOS};
+    const asset GAS_FEE = asset{0'0100, EOS};
     const asset NET = asset{1'0000, EOS};
     const asset CPU = asset{1'0000, EOS};
     const uint32_t RAM = 8000;
-    const uint32_t TIMEOUT = 1; // 1 seconds
-    const uint32_t MAX_AGE = 3600; // 60 minutes
-    const uint32_t MAX_RECEIVED = 1000; // max received
+    const uint32_t TIMEOUT = 60; // 1 minute
+    const uint32_t TTL_HISTORY = 600; // 1 hour
+    const uint32_t TTL_RATE_LIMIT = 86400; // 24 hours
+    const uint32_t MAX_RECEIVED = 10; // max received
     const string MEMO = "received by https://faucet.testnet.evm.eosnetwork.com";
 
     /**
@@ -180,8 +183,9 @@ private :
 
     void send_evm( const string address );
     void send_eos( const string address );
-    void add_ratelimit( const string address );
+    uint64_t add_ratelimit( const string address );
     void add_history( const string address );
+    void prune_rate_limit();
     void prune_history();
     void add_stats();
 };


### PR DESCRIPTION
- Prune `ratelimits` table
- Prune single use `ratelimit` values
- Adjust timeout to 60 seconds
- Adjust TTL to 24 hours for rate limit
- Add decrement by 0.1 EOS per counter